### PR TITLE
Updating catch-all error to non 400 so Zuora can retry

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::APIBaseController < ApplicationController
     puts ex5.backtrace
     error = {:code => 500, :message => "Internal server error"}
     respond_to do |format|
-      format.json { render json: {"success" => false, "error" => error}, status: :bad_request }
+      format.json { render json: {"success" => false, "error" => error}, status: :internal_server_error }
     end
   end
 


### PR DESCRIPTION
Zuora does not retry 400 http response codes so updating the catch-all to be something that Zuora will retry.

The catch-all does not necessarily represent a bad request as any uncaught exception (including system outages or delays in the authentication service) gets pushed here.